### PR TITLE
Add wait ready flag

### DIFF
--- a/nginx_pm2_krakenjs/krakenapp/env.json
+++ b/nginx_pm2_krakenjs/krakenapp/env.json
@@ -3,6 +3,7 @@
     "name": "krakenapp",
     "script": "server.js",
     "instances": "2",
-    "exec_mode": "cluster"
+    "exec_mode": "cluster",
+    "wait_ready": true
   }]
 }

--- a/nginx_pm2_krakenjs/krakenapp/server.js
+++ b/nginx_pm2_krakenjs/krakenapp/server.js
@@ -14,4 +14,5 @@ server = http.createServer(app);
 server.listen(process.env.PORT || 8000);
 server.on('listening', function () {
     console.log('Server listening on http://localhost:%d', this.address().port);
+    process.send('ready');
 });


### PR DESCRIPTION
It seems as though PM2 will only send requests to a worker when the [.listen() has been called.](https://github.com/Unitech/pm2/issues/2353) but this gives a nice explicit way to send a [`ready`](http://pm2.keymetrics.io/docs/usage/signals-clean-restart/#graceful-start) message if something needs to be warmed up.

